### PR TITLE
fix: omnibox uncaught exception and addressed npm audit and jest issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Once you click the icon in Chrome, or activate the keyboard shortcut, you should
 # I want to hack on it
 
     git clone https://github.com/anth0d/chrome-confluence-search.git
+    cd chrome-confluence-search
+    npm install && npm build
     open chrome://extensions
     # click "LOAD UNPACKED"
-    # select the location you cloned into
+    # navigate to this repo, and select the "dist" folder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-confluence-search",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Quickly search your team documentation at the press of a button",
   "private": true,
   "scripts": {
@@ -36,7 +36,7 @@
     "@types/webpack": "^4.39.8",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
     "@typescript-eslint/parser": "^4.14.0",
-    "copy-webpack-plugin": "^5.0.5",
+    "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^5.0.1",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
@@ -45,8 +45,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "html-webpack-plugin": "^4.5.1",
     "husky": "^4.3.8",
-    "jest": "^24.9.0",
-    "jest-cli": "^24.9.0",
+    "jest": "^27.2.0",
+    "jest-cli": "^27.2.0",
     "jest-fetch-mock": "^3.0.3",
     "neverthrow": "^4.0.1",
     "npm-run-all": "^4.1.5",
@@ -54,12 +54,12 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "style-loader": "^2.0.0",
-    "ts-jest": "^24.1.0",
+    "ts-jest": "^27.0.5",
     "ts-loader": "^6.2.1",
     "ts-node": "^8.5.0",
     "typescript": "^3.7.2",
-    "webpack": "^4.41.2",
-    "webpack-cli": "^3.3.10"
+    "webpack": "^5.52.1",
+    "webpack-cli": "^4.8.0"
   },
   "husky": {
     "hooks": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Confluence Quick Search",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Quickly search your team's Confluence at the press of a button. ...also, adds the shortcut 'con' to the Chrome omnibox.",
   "manifest_version": 2,
   "short_name": "confluence-quick-search",

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,16 +5,18 @@ import { getSiteUrl } from "./utils/data";
 const installHandler = (details: chrome.runtime.InstalledDetails): void => {
   _gaq.push(["_trackEvent", "install"]);
   chrome.omnibox.onInputEntered.addListener(function (text) {
-    getSiteUrl().then((siteUrl) => {
-      if (!siteUrl) {
-        _gaq.push(["_trackEvent", "omnibox", "failure"]);
-        alert("Click the extension and set a Confluence URL");
-        return;
-      } else {
-        _gaq.push(["_trackEvent", "omnibox", "success"]);
-        chrome.tabs.create({ url: `${siteUrl}/dosearchsite.action?queryString=${encodeURIComponent(text)}` });
-      }
-    });
+    getSiteUrl()
+      .then((siteUrl) => {
+        if (!siteUrl) {
+          _gaq.push(["_trackEvent", "omnibox", "failure"]);
+          alert("Click the extension and set a Confluence URL");
+          return;
+        } else {
+          _gaq.push(["_trackEvent", "omnibox", "success"]);
+          chrome.tabs.create({ url: `${siteUrl}/dosearchsite.action?queryString=${encodeURIComponent(text)}` });
+        }
+      })
+      .catch(console.dir);
   });
   if (details.reason !== "install") {
     // no need to show notification

--- a/src/background.ts
+++ b/src/background.ts
@@ -8,15 +8,17 @@ const installHandler = (details: chrome.runtime.InstalledDetails): void => {
     getSiteUrl()
       .then((siteUrl) => {
         if (!siteUrl) {
-          _gaq.push(["_trackEvent", "omnibox", "failure"]);
+          _gaq.push(["_trackEvent", "omnibox", "alert"]);
           alert("Click the extension and set a Confluence URL");
-          return;
         } else {
           _gaq.push(["_trackEvent", "omnibox", "success"]);
           chrome.tabs.create({ url: `${siteUrl}/dosearchsite.action?queryString=${encodeURIComponent(text)}` });
         }
       })
-      .catch(console.dir);
+      .catch((err) => {
+        console.error(err);
+        _gaq.push(["_trackEvent", "omnibox", "error"]);
+      });
   });
   if (details.reason !== "install") {
     // no need to show notification

--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -47,4 +47,9 @@ describe("getSiteUrl", () => {
     setup({ sOutput: "https://mysite.com/confluence", cOutput: "sdf" });
     expect(await getSiteUrl()).toBe("https://mysite.com/confluence");
   });
+
+  test("existing url with trailing slash", async () => {
+    setup({ sOutput: "https://mysite.com/wiki/", cOutput: "sdf" });
+    expect(await getSiteUrl()).toBe("https://mysite.com/wiki");
+  });
 });

--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { getSiteUrl } from "./data";
 
 interface Extension {

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -9,10 +9,17 @@ export const saveSiteUrl = async (siteUrl: string): Promise<void> => {
 export const getSiteUrl = async (): Promise<string> => {
   const url = await getString("siteUrl");
   if (url) {
-    return url;
+    if (url.endsWith("/")) {
+      // emit a metric to help avoid breaking things in the future
+      _gaq.push(["_trackEvent", "data", "siteUrlTrailingSlash"]);
+    }
+    // trim trailing slash if present
+    return url.replace(/\/$/, "");
   }
   const fallback = await getString("confluenceUrl");
   if (fallback) {
+    // emit a metric to help avoid breaking things in the future
+    _gaq.push(["_trackEvent", "data", "confluenceUrlExists"]);
     return `https://${fallback}/wiki`;
   }
   // default

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,8 +41,8 @@ module.exports = {
     extensions: [".ts", ".tsx", ".js"],
   },
   plugins: [
-    new CopyPlugin([{ from: ".", to: "." }], {
-      context: "public",
+    new CopyPlugin({
+      patterns: [{ from: ".", to: ".", context: "public" }],
     }),
     new HtmlWebpackPlugin(
       Object.assign(


### PR DESCRIPTION
Addresses the uncaught exception causing https://github.com/anth0d/chrome-confluence-search/issues/8 and the lack of input validation causing https://github.com/anth0d/chrome-confluence-search/issues/9